### PR TITLE
Fix broken compilation, and do some Go style cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-#iTunes Export Console (golang)##
+## iTunes Export Console (golang)
 
 A console application that exports iTunes Playlists using the iTunes Music Library.xml plist.
 
 This is a port of the previous Scala version, found here: https://code.google.com/p/itunesexport-scala/ and .Net version, found here: http://www.ericdaugherty.com/dev/itunesexport/1.x/ 
 
-##Usage##
+## Usage
 
-itunesexport -library < path to .xml file >
+```
+go build 
+./itunesexport -library <path to .xml file>
+```

--- a/app.go
+++ b/app.go
@@ -14,7 +14,7 @@ const (
 	UsageMessage = `usage: %v [<flags>] [include <playlist name>...]
 	
 Flags:
-    -library <file path>        Path to iTunes Music Libary XML File.
+    -library <file path>        Path to iTunes Music Library XML File.
     -output <file path>         Path where the playlists should be written.
     -type <M3U|EXT|WPL|ZPL>     Type of playlist file to write.  Defaults to M3U
                                 EXT = M3U Extended, WPL = Windows Playlist, ZPL = Zune Playlist
@@ -116,7 +116,7 @@ func main() {
 	fmt.Println("Loading Library:", libraryPath)
 	library, err := LoadLibrary(libraryPath)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Println(err)
 		return
 	}
 	exportSettings.Library = library
@@ -128,7 +128,8 @@ func main() {
 	fmt.Printf("Exporting %v playlists...\n", len(exportSettings.Playlists))
 	err = ExportPlaylists(&exportSettings, library)
 	if err != nil {
-		fmt.Printf("Error Exporting Playlist: %v\n", err.Error())
+		fmt.Printf("Error Exporting Playlist: %v\n", err)
+		return
 	}
 }
 
@@ -168,7 +169,8 @@ func parseCopyType() error {
 	return nil
 }
 
-func parsePlaylists(library *Library) (playlists []Playlist) {
+func parsePlaylists(library *Library) []Playlist {
+	var playlists []Playlist
 	if includeAllPlaylists {
 		for _, value := range library.Playlists {
 			if value.DistinguishedKind == 0 && value.Name != "Library" {
@@ -186,7 +188,7 @@ func parsePlaylists(library *Library) (playlists []Playlist) {
 			if ok {
 				playlists = append(playlists, playlist)
 			} else {
-				fmt.Printf("Unable to find matching playlist for name: %v  Skipping Playlist.\n", playlistName)
+				fmt.Printf("Unable to find matching playlist for name: %q. Skipping Playlist.\n", playlistName)
 			}
 
 		}

--- a/export.go
+++ b/export.go
@@ -37,7 +37,6 @@ type ExportSettings struct {
 }
 
 func ExportPlaylists(exportSettings *ExportSettings, library *Library) error {
-
 	start := time.Now()
 
 	for _, playlist := range exportSettings.Playlists {
@@ -77,12 +76,11 @@ func ExportPlaylists(exportSettings *ExportSettings, library *Library) error {
 		for _, track := range playlist.Tracks(exportSettings.Library) {
 
 			sourceFileLocation, errParse := url.QueryUnescape(track.Location)
-			sourceFileLocation = trimTrackLocationPrefix(fileLocation)
+			sourceFileLocation = trimTrackLocationPrefix(sourceFileLocation)
 
-
-			playlistFileLocation, err := copyTrack(exportSettings, library, &playlist, &track)
+			destFileLocation, err := copyTrack(exportSettings, &playlist, &track, sourceFileLocation)
 			if err != nil {
-				fmt.Printf("Unable to copy file %v Error: %v\n", fileLocation, err.Error())
+				fmt.Printf("Unable to copy file %v: %v\n", sourceFileLocation, err.Error())
 				continue
 			}
 
@@ -91,7 +89,7 @@ func ExportPlaylists(exportSettings *ExportSettings, library *Library) error {
 				continue
 			}
 
-			err := entry(file, exportSettings, &playlist, &track, fileLocation)
+			err = entry(file, exportSettings, &playlist, &track, destFileLocation)
 			if err != nil {
 				return err
 			}
@@ -110,10 +108,10 @@ func ExportPlaylists(exportSettings *ExportSettings, library *Library) error {
 	return nil
 }
 
-func copyTrack(exportSettings *ExportSettings, library *Library, playlist *Playlist, track *Track, sourceFileLocation string) (playlistFileLocation string, error) {
-
-	var destinationPath = ""
-
+// copyTrack copies a file from the provided sourceFileLocation to another location. The new location
+// depends on the CopyType selected in exportSettings. If COPY_NONE is selected, the sourceFileLocation is returned.
+func copyTrack(exportSettings *ExportSettings, playlist *Playlist, track *Track, sourceFileLocation string) (string, error) {
+	var destinationPath string
 	switch exportSettings.CopyType {
 	case COPY_PLAYLIST:
 		destinationPath = filepath.Join(exportSettings.OutputPath, playlist.Name)
@@ -121,26 +119,27 @@ func copyTrack(exportSettings *ExportSettings, library *Library, playlist *Playl
 		destinationPath = filepath.Join(exportSettings.OutputPath, track.Artist, track.Album)
 	case COPY_FLAT:
 		destinationPath = exportSettings.OutputPath
+	case COPY_NONE:
+		return sourceFileLocation, nil
 	default:
-		return errors.New("Unknown Copy Type")
+		return "", errors.New("Unknown Copy Type")
 	}
+	dest := filepath.Join(destinationPath, filepath.Base(sourceFileLocation))
 
-	dest := filepath.Join(destinationPath, filepath.Base(fileLocation))
-
-	return copyFile(fileLocation, dest)
-
+	if err := copyFile(sourceFileLocation, dest); err != nil {
+		return "", err
+	}
 	return destinationPath, nil
 }
 
 func copyFile(src, dest string) error {
-
 	sourceFileInfo, err := os.Stat(src)
 	if err != nil {
 		return err
 	}
 
 	if !sourceFileInfo.Mode().IsRegular() {
-		errors.New("Source file is not a regular file.")
+		return errors.New("Source file is not a regular file.")
 	}
 
 	_, err = os.Stat(dest)
@@ -167,8 +166,7 @@ func copyFile(src, dest string) error {
 	return copyFileData(src, dest)
 }
 
-func copyFileData(src, dest string) (err error) {
-
+func copyFileData(src, dest string) error {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -184,6 +182,5 @@ func copyFileData(src, dest string) (err error) {
 	if _, err = io.Copy(out, in); err != nil {
 		return err
 	}
-	err = out.Sync()
-	return
+	return out.Sync()
 }

--- a/export.go
+++ b/export.go
@@ -129,7 +129,7 @@ func copyTrack(exportSettings *ExportSettings, playlist *Playlist, track *Track,
 	if err := copyFile(sourceFileLocation, dest); err != nil {
 		return "", err
 	}
-	return destinationPath, nil
+	return dest, nil
 }
 
 func copyFile(src, dest string) error {

--- a/library.go
+++ b/library.go
@@ -71,17 +71,14 @@ type PlaylistItem struct {
 	TrackId int `plist:"Track ID"`
 }
 
-func LoadLibrary(fileLocation string) (returnLibrary *Library, err error) {
-
+func LoadLibrary(fileLocation string) (*Library, error) {
 	if _, statErr := os.Stat(fileLocation); os.IsNotExist(statErr) {
-		err = statErr
-		return
+		return nil, statErr
 	}
 
 	file, pathErr := os.Open(fileLocation)
 	if pathErr != nil {
-		err = pathErr
-		return
+		return nil, pathErr
 	}
 
 	decoder := plist.NewDecoder(file)
@@ -89,8 +86,7 @@ func LoadLibrary(fileLocation string) (returnLibrary *Library, err error) {
 	var library Library
 	decodeErr := decoder.Decode(&library)
 	if decodeErr != nil {
-		err = decodeErr
-		return
+		return nil, decodeErr
 	}
 
 	library.PlaylistMap = make(map[string]Playlist)
@@ -98,15 +94,16 @@ func LoadLibrary(fileLocation string) (returnLibrary *Library, err error) {
 		library.PlaylistMap[value.Name] = value
 	}
 
-	return &library, err
+	return &library, nil
 }
 
-func (playlist *Playlist) Tracks(library *Library) (tracks []Track) {
+func (playlist *Playlist) Tracks(library *Library) ([]Track) {
+	var tracks []Track
 	for _, item := range playlist.PlaylistItems {
 		track, ok := library.Tracks[strconv.FormatInt(int64(item.TrackId), 10)]
 		if ok {
 			tracks = append(tracks, track)
 		}
 	}
-	return
+	return tracks
 }

--- a/platform_windows.go
+++ b/platform_windows.go
@@ -15,5 +15,5 @@ func defaultLibraryPath() string {
 }
 
 func trimTrackLocationPrefix(path string) string {
-	return strings.TrimPrefix(path, "file://localhost/"
+	return strings.TrimPrefix(path, "file://localhost/")
 }

--- a/playlistwriters.go
+++ b/playlistwriters.go
@@ -11,17 +11,17 @@ func m3uPlaylistWriters() (header playlistWriter, entry trackWriter, footer play
 	const headerString = "# M3U Playlist '%v' exported %v by iTunes Export v. %v (http://www.ericdaugherty.com/dev/itunesexport/)\n"
 	const entryString = "%v\n"
 
-	header = func(w io.Writer, exportSettings *ExportSettings, playlist *Playlist) error {
+	header = func(w io.Writer, _ *ExportSettings, playlist *Playlist) error {
 		_, err := w.Write([]byte(fmt.Sprintf(headerString, playlist.Name, time.Now().Format("2006-01-02 3:04PM"), Version)))
 		return err
 	}
 
-	entry = func(w io.Writer, exporterSetting *ExportSettings, playlist *Playlist, track *Track, fileLocation string) error {
+	entry = func(w io.Writer, _ *ExportSettings, _ *Playlist, _ *Track, fileLocation string) error {
 		_, err := w.Write([]byte(fmt.Sprintf(entryString, fileLocation)))
 		return err
 	}
 
-	footer = func(w io.Writer, exportSettings *ExportSettings, playlist *Playlist) error {
+	footer = func(_ io.Writer, _ *ExportSettings, _ *Playlist) error {
 		return nil
 	}
 
@@ -33,17 +33,17 @@ func extPlaylistWriters() (header playlistWriter, entry trackWriter, footer play
 	const headerString = "#EXTM3U\n"
 	const entryString = "#EXTINF:%v,%v - %v\n%v\n"
 
-	header = func(w io.Writer, exportSettings *ExportSettings, playlist *Playlist) error {
+	header = func(w io.Writer, _ *ExportSettings, _ *Playlist) error {
 		_, err := w.Write([]byte(fmt.Sprintf(headerString)))
 		return err
 	}
 
-	entry = func(w io.Writer, exporterSetting *ExportSettings, playlist *Playlist, track *Track, fileLocation string) error {
+	entry = func(w io.Writer, _ *ExportSettings, _ *Playlist, track *Track, fileLocation string) error {
 		_, err := w.Write([]byte(fmt.Sprintf(entryString, track.TotalTime/1000, track.Artist, track.Name, fileLocation)))
 		return err
 	}
 
-	footer = func(w io.Writer, exportSettings *ExportSettings, playlist *Playlist) error {
+	footer = func(_ io.Writer, _ *ExportSettings, _ *Playlist) error {
 		return nil
 	}
 
@@ -68,17 +68,17 @@ func wplPlaylistWriters() (header playlistWriter, entry trackWriter, footer play
 </smil>
 `
 
-	header = func(w io.Writer, exportSettings *ExportSettings, playlist *Playlist) error {
+	header = func(w io.Writer, _ *ExportSettings, playlist *Playlist) error {
 		_, err := w.Write([]byte(fmt.Sprintf(headerString, playlist.Name)))
 		return err
 	}
 
-	entry = func(w io.Writer, exporterSetting *ExportSettings, playlist *Playlist, track *Track, fileLocation string) error {
+	entry = func(w io.Writer, _ *ExportSettings, _ *Playlist, _ *Track, fileLocation string) error {
 		_, err := w.Write([]byte(fmt.Sprintf(entryString, fileLocation)))
 		return err
 	}
 
-	footer = func(w io.Writer, exportSettings *ExportSettings, playlist *Playlist) error {
+	footer = func(w io.Writer, _ *ExportSettings, _ *Playlist) error {
 		_, err := w.Write([]byte(footerString))
 		return err
 	}
@@ -105,17 +105,17 @@ func zplPlaylistWriters() (header playlistWriter, entry trackWriter, footer play
 </smil>
 `
 
-	header = func(w io.Writer, exportSettings *ExportSettings, playlist *Playlist) error {
+	header = func(w io.Writer, _ *ExportSettings, playlist *Playlist) error {
 		_, err := w.Write([]byte(fmt.Sprintf(headerString, playlist.Name)))
 		return err
 	}
 
-	entry = func(w io.Writer, exporterSetting *ExportSettings, playlist *Playlist, track *Track, fileLocation string) error {
+	entry = func(w io.Writer, _ *ExportSettings, _ *Playlist, _ *Track, fileLocation string) error {
 		_, err := w.Write([]byte(fmt.Sprintf(entryString, fileLocation)))
 		return err
 	}
 
-	footer = func(w io.Writer, exportSettings *ExportSettings, playlist *Playlist) error {
+	footer = func(w io.Writer, _ *ExportSettings, _ *Playlist) error {
 		_, err := w.Write([]byte(footerString))
 		return err
 	}


### PR DESCRIPTION
There were a few compiler errors:
* `fileLocation` was not set in multiple locations.
* copyTrack() had two returns next to each other - the second could never happen.
* copyFile() had an errors.New call that wasn't being returned.
* Missing parenthesis in platform_windows.go

There were a few minor issues, like a call to `errors.New` that didn't return the error.

When using COPY_NONE, the tool seemed to be exporting m3u files only containing a header and no other content, so I added a case for COPY_NONE in `export.copyTrack` so that the source file path would be used instead of the path being skipped.

I also made a number of Go style changes, like changing the name of unused params in playlistwriters to underscore. Also explicitly returning values rather than using named returns. Named returns are more commonly used when there are two values of the same type (e.g. `(string,string)` would be better as `(name, value string)` - using them instead of declaring values can be harder to follow.

I tested manually on my iTunes library:
go build
./itunesexport-go.exe -library=./iTunes\ Music\ Library.xml -output=./output/ -includeAllWithBuiltin

and it appears to have worked. The output directory has a bunch of m3u files, similar to:
```
# M3U Playlist '2020 In Review' exported 2021-01-17 7:28PM by iTunes Export v. DEV (http://www.ericdaugherty.com/dev/itunesexport/)
D:/iTunes/iTunes Media/Music/Sebalter/Day Of Glory/1-03 Day Of Glory.mp3
D:/iTunes/iTunes Media/Music/Family and Friends/XOXO/1-02 Amadeus.mp3
D:/iTunes/iTunes Media/Music/Josh Ritter/Fever Breaks/1-01 Ground Don't Want Me.mp3
```