### PR TITLE
Add the new-ish `Loved` track field.

### DIFF
--- a/library.go
+++ b/library.go
@@ -53,6 +53,7 @@ type Track struct {
 	Location            string
 	FileFolderCount     int `plist:"File Folder Count"`
 	LibraryFolderCount  int `plist:"Library Folder Count"`
+	Loved               bool `plist:"Loved"`
 }
 
 type Playlist struct {


### PR DESCRIPTION
I'm not sure when they added it, but I'm using iTunes 12.6. It appears to have existed at least in 2015.

I tested this code parsing my itunes xml file and it worked. The relevant key looks like:
`<key>Loved</key><true/>`
I didn't see any instances of `<key>Loved</key><false/>` so it appears to only be set when true.