### PR TITLE
Add additional fields to Track

### DIFF
--- a/library.go
+++ b/library.go
@@ -33,7 +33,12 @@ type Track struct {
 	Kind                string
 	Size                int
 	TotalTime           int `plist:"Total Time"`
+	StartTime           int `plist:"Start Time"`
+	StopTime            int `plist:"Stop Time"`
 	TrackNumber         int `plist:"Track Number"`
+	TrackCount          int `plist:"Track Count"`
+	DiscNumber          int `plist:"Disc Number"`
+	DiscCount           int `plist:"Disc Count"`
 	Year                int
 	DateModified        time.Time `plist:"Date Modified"`
 	DateAdded           time.Time `plist:"Date Added"`
@@ -53,7 +58,17 @@ type Track struct {
 	Location            string
 	FileFolderCount     int `plist:"File Folder Count"`
 	LibraryFolderCount  int `plist:"Library Folder Count"`
-	Loved               bool `plist:"Loved"`
+	Loved               bool
+	Disabled            bool
+	Comments            string
+	SortName            string `plist:"Sort Name"`
+	SortAlbum           string `plist:"Sort Album"`
+	SortAlbumArtist     string `plist:"Sort Album Artist"`
+	SortArtist          string `plist:"Sort Artist"`
+	SortComposer        string `plist:"Sort Composer"`
+	Work                string
+	Grouping            string
+	VolumeAdjustment    int `plist:"Volume Adjustment"`
 }
 
 type Playlist struct {


### PR DESCRIPTION
I noticed these in my itunes music xml file.

`<key>Total Time</key><integer>194693</integer>`
`<key>Start Time</key><integer>25000</integer>`
Start and Stop Time make playback start and end at specific times. Total Time appears to be optional, and only set when Start/End Time is set.  Units are milliseconds.

Track/Disc Count/Number are self explanatory.

`<key>Disabled</key><true/>`
Disabled corresponds to the checkbox next to songs, which causes them to not be played unless they are directly added to the "Up Next" list.

`<key>Comments</key><string>http://www.jamendo.com Attribution 3.0 </string>`
Comments are user provided strings, but they can also store attribution information or whatever else people include.

`<key>Sort Album</key><string>Simple Life</string>`
Sort Album is used to determine how sorting works. In this case the album was "The Simple Life" but because of this key, it shows up under S rather than T.
Same for the other sort fields.

Work is meant for tagging classical music, based on https://discussions.apple.com/thread/7852053
Grouping also appears to be for classical music, based on https://kirkville.com/what-is-the-itunes-grouping-ta
They don't seem to be used properly in my library (often they are filled in with the Genre), but it doesn't hurt to include them here.

`<key>Volume Adjustment</key><integer>255</integer>`
This for manual volume adjustment for a single track. In the UI it shows as a range of -100% to +100%. +100% results in 255 here.

Tested by running on my itunes xml file. No issues.