### PR TITLE
Feature/Linux WSL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 itunesexport-go
+itunesexport-go.exe
 output
 *.m3u
 *.wpl

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ package: build
 	mv itunesexport-go.exe output/itunesexport.exe
 	GOOS=windows GOARCH=amd64 go build -v -ldflags "-X main.Version $(buildnumber)"
 	mv itunesexport-go.exe output/itunesexport64.exe
-	
+
+test:
+	go test
+
 clean:
 	rm -Rf itunesexport-go
 	rm -Rf output

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,17 @@ package: build
 	GOOS=windows GOARCH=amd64 go build -v -ldflags "-X main.Version $(buildnumber)"
 	mv itunesexport-go.exe output/itunesexport64.exe
 
-test:
+test: clean test-build
 	go test
 
+test-build:
+	GOOS=darwin go build
+	GOOS=windows go build
+	GOOS=linux go build
+	make clean
+
 clean:
-	rm -Rf itunesexport-go
+	rm -Rf itunesexport-go*
 	rm -Rf output
 
 run: build

--- a/app.go
+++ b/app.go
@@ -101,7 +101,6 @@ func main() {
 			case ModeUnknown:
 				commandLineError = true
 				commandLineErrorMessage = fmt.Sprintf("Unexpected paramter %v\n", flagValue)
-				break
 			case ModeInclude:
 				includePlaylistNames = append(includePlaylistNames, flagValue)
 			}

--- a/app.go
+++ b/app.go
@@ -115,7 +115,11 @@ func main() {
 	}
 
 	if libraryPath == "" {
-		libraryPath = defaultLibraryPath()
+		libraryPath, err = defaultLibraryPath()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
 	}
 	libraryPath = filepath.Clean(libraryPath)
 

--- a/export.go
+++ b/export.go
@@ -54,10 +54,10 @@ func ExportPlaylists(exportSettings *ExportSettings, library *Library) error {
 		fileName := filepath.Join(exportSettings.OutputPath, safePlaylistName+"."+exportSettings.Extension)
 
 		file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
-		defer file.Close()
 		if err != nil {
 			return err
 		}
+		defer file.Close()
 
 		var header playlistWriter
 		var entry trackWriter
@@ -72,7 +72,7 @@ func ExportPlaylists(exportSettings *ExportSettings, library *Library) error {
 		case ZPL:
 			header, entry, footer = zplPlaylistWriters()
 		default:
-			return errors.New("Export Type Not Implemented")
+			return errors.New("export type not implemented")
 		}
 
 		// Write out the Header
@@ -134,7 +134,7 @@ func copyTrack(exportSettings *ExportSettings, playlist *Playlist, track *Track,
 		}
 		return sourceFileLocation, nil
 	default:
-		return "", errors.New("Unknown Copy Type")
+		return "", errors.New("unknown copy type")
 	}
 	dest := filepath.Join(destinationPath, filepath.Base(sourceFileLocation))
 
@@ -151,7 +151,7 @@ func copyFile(src, dest string) error {
 	}
 
 	if !sourceFileInfo.Mode().IsRegular() {
-		return errors.New("Source file is not a regular file.")
+		return errors.New("source file is not a regular file.")
 	}
 
 	_, err = os.Stat(dest)

--- a/platform_darwin.go
+++ b/platform_darwin.go
@@ -10,8 +10,8 @@ func isWindows() bool {
 	return false
 }
 
-func defaultLibraryPath() string {
-	return fmt.Sprintf("/Users/%v/Music/iTunes/iTunes Music Library.xml", os.Getenv("USER"))
+func defaultLibraryPath() (string, error) {
+	return fmt.Sprintf("/Users/%v/Music/iTunes/iTunes Music Library.xml", os.Getenv("USER")), nil
 }
 
 func trimTrackLocationPrefix(path string) string {

--- a/platform_darwin.go
+++ b/platform_darwin.go
@@ -6,10 +6,6 @@ import (
 	"strings"
 )
 
-func isWindows() bool {
-	return false
-}
-
 func defaultLibraryPath() (string, error) {
 	return fmt.Sprintf("/Users/%v/Music/iTunes/iTunes Music Library.xml", os.Getenv("USER")), nil
 }

--- a/platform_linux.go
+++ b/platform_linux.go
@@ -11,11 +11,6 @@ import (
 // we assume the drive was mounted to this path
 const DefaultLinuxDrive = "/mnt/itunes"
 
-func isWindows() bool {
-	return false
-}
-
-
 func defaultLibraryPath() (string, error) {
 	return defaultLibraryPathInternal(execCmd)
 }

--- a/platform_linux.go
+++ b/platform_linux.go
@@ -15,11 +15,13 @@ func isWindows() bool {
 	return false
 }
 
-func defaultLibraryPath() string {
-	return fmt.Sprintf("/Users/%v/Music/iTunes/iTunes Music Library.xml", os.Getenv("USER"))
+
+func defaultLibraryPath() (string, error) {
+	return defaultLibraryPathInternal(execCmd)
 }
 
-func defaultLibraryPath2(cmdExecFunc func(command string) (string, error)) (string, error) {
+
+func defaultLibraryPathInternal(cmdExecFunc func(command string) (string, error)) (string, error) {
 	if (os.Getenv("WSLENV") != "") {
 		return determineWslDefaultLibraryPath(cmdExecFunc)
 	} else {

--- a/platform_linux.go
+++ b/platform_linux.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// as iTunes does not nativly run under Linux, 
+// we assume the drive was mounted to this path
+const DefaultLinuxDrive = "/mnt/itunes"
+
+func isWindows() bool {
+	return false
+}
+
+func defaultLibraryPath() string {
+	return fmt.Sprintf("/Users/%v/Music/iTunes/iTunes Music Library.xml", os.Getenv("USER"))
+}
+
+func defaultLibraryPath2(cmdExecFunc func(command string) (string, error)) (string, error) {
+	if (os.Getenv("WSLENV") != "") {
+		return determineWslDefaultLibraryPath(cmdExecFunc)
+	} else {
+		return DefaultLinuxDrive, nil
+	}
+}
+
+func determineWslDefaultLibraryPath(execCmdFunc func(command string) (string, error)) (string, error) {
+	homeDrive, err := execCmdFunc("echo %HOMEDRIVE%")
+	if err != nil {
+		return "", err
+	}
+	homeDrive = strings.ToLower(strings.TrimRight(homeDrive, ":"))
+
+	homePath, err := execCmdFunc("echo %HOMEPATH%")
+	if err != nil {
+		return "", err
+	}
+	homePath = strings.ReplaceAll(homePath, "\\", "/")
+
+	return fmt.Sprintf("/mnt/%v%v/Music/iTunes/iTunes Music Library.xml", homeDrive, homePath), nil
+}
+
+func execCmd(command string) (string, error) {
+	result, err := exec.Command("cmd.exe", "/c", command).Output()
+	if (err != nil) {
+		return "", err;
+	}
+	return strings.TrimSpace(string(result)), nil
+
+}
+
+func trimTrackLocationPrefix(path string) string {
+	return strings.TrimPrefix(path, "file://localhost")
+}

--- a/platform_linux.go
+++ b/platform_linux.go
@@ -46,7 +46,6 @@ func execCmd(command string) (string, error) {
 		return "", err;
 	}
 	return strings.TrimSpace(string(result)), nil
-
 }
 
 func trimTrackLocationPrefix(path string) string {

--- a/platform_linux_test.go
+++ b/platform_linux_test.go
@@ -19,7 +19,7 @@ func TestGetDefaultLibraryInWsl(t *testing.T) {
 			cnt++
 			return "\\Users\\SomeUser", nil
 		default:
-			return "", errors.New("Function called too often")
+			return "", errors.New("function called too often")
 		}
 	}
 

--- a/platform_linux_test.go
+++ b/platform_linux_test.go
@@ -24,7 +24,7 @@ func TestGetDefaultLibraryInWsl(t *testing.T) {
 	}
 
 	os.Setenv("WSLENV", "FOO")
-	result, err := defaultLibraryPath2(fakeExecCmdFunc)
+	result, err := defaultLibraryPathInternal(fakeExecCmdFunc)
 	if (err != nil) {
 		t.Fail()
 		t.Logf("function return error")
@@ -44,7 +44,7 @@ func TestGetDefaultLibraryInLinux(t *testing.T) {
 	}
 
 	os.Unsetenv("WSLENV")
-	result, err := defaultLibraryPath2(stubFunc)
+	result, err := defaultLibraryPathInternal(stubFunc)
 	if (err != nil) {
 		t.Fail()
 		t.Logf("function return error")

--- a/platform_linux_test.go
+++ b/platform_linux_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestGetDefaultLibraryInWsl(t *testing.T) {
+
+	cnt := 0
+
+	fakeExecCmdFunc := func(_ string) (string, error) {
+		switch (cnt) {
+		case 0:
+			cnt++
+			return "C:", nil
+		case 1:
+			cnt++
+			return "\\Users\\SomeUser", nil
+		default:
+			return "", errors.New("Function called too often")
+		}
+	}
+
+	os.Setenv("WSLENV", "FOO")
+	result, err := defaultLibraryPath2(fakeExecCmdFunc)
+	if (err != nil) {
+		t.Fail()
+		t.Logf("function return error")
+	}
+	
+	expected := "/mnt/c/Users/SomeUser/Music/iTunes/iTunes Music Library.xml"
+	if (result != expected) {
+		t.Fail()
+		t.Logf("expected %v, got %v", expected, result)
+	}
+}
+
+func TestGetDefaultLibraryInLinux(t *testing.T) {
+
+	stubFunc := func(_ string) (string, error) {
+		return "", nil
+	}
+
+	os.Unsetenv("WSLENV")
+	result, err := defaultLibraryPath2(stubFunc)
+	if (err != nil) {
+		t.Fail()
+		t.Logf("function return error")
+	}
+	
+	expected := "/mnt/itunes"
+	if (result != expected) {
+		t.Fail()
+		t.Logf("expected %v, got %v", expected, result)
+	}
+}
+

--- a/platform_windows.go
+++ b/platform_windows.go
@@ -10,8 +10,8 @@ func isWindows() bool {
 	return true
 }
 
-func defaultLibraryPath() string {
-	return fmt.Sprintf("%v%v\\Music\\iTunes\\iTunes Music Library.xml", os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"))
+func defaultLibraryPath() (string, error) {
+	return fmt.Sprintf("%v%v\\Music\\iTunes\\iTunes Music Library.xml", os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH")), nil
 }
 
 func trimTrackLocationPrefix(path string) string {

--- a/platform_windows.go
+++ b/platform_windows.go
@@ -6,10 +6,6 @@ import (
 	"strings"
 )
 
-func isWindows() bool {
-	return true
-}
-
 func defaultLibraryPath() (string, error) {
 	return fmt.Sprintf("%v%v\\Music\\iTunes\\iTunes Music Library.xml", os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH")), nil
 }


### PR DESCRIPTION
This PR enables using the exporter under Linux/ Windows Subsystem for Linux (WSL). I used  `itunesepxorter-go`  with some shell scripting to extract playlists + audio files of an iTunes Library sitting on the Windows side of my machine.

Added:
- `platform_linux.go` plus unit test
- supports normal Linux plus WSL
- new make target `test` to test 
  - multi-platform build
  - execute unit tests

Cleanup aka "Random act of kindness":
- fix go-static warnings ("no upper case errors", "remove redundant break"...)
- delete obsolete function `isWindows`