### PR TITLE
fix build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ package: build
 	rm -Rf output
 	mkdir output
 	mv itunesexport-go output/itunesexport
-	GOOS=windows GOARCH=386 go build -v -ldflags "-X main.Version $(buildnumber)"
+	GOOS=windows GOARCH=386 go build -v -ldflags "-X main.Version=$(buildnumber)"
 	mv itunesexport-go.exe output/itunesexport.exe
-	GOOS=windows GOARCH=amd64 go build -v -ldflags "-X main.Version $(buildnumber)"
+	GOOS=windows GOARCH=amd64 go build -v -ldflags "-X main.Version=$(buildnumber)"
 	mv itunesexport-go.exe output/itunesexport64.exe
 
 test: clean test-build


### PR DESCRIPTION
fixes this error: `/home/linuxbrew/.linuxbrew/Cellar/go/1.20.3/libexec/pkg/tool/linux_amd64/link: -X flag requires argument of the form importpath.name=value`

Maybe build was behaving differently in previous Go lang versions ? 🤔